### PR TITLE
User Story 5

### DIFF
--- a/app/controllers/laugh_tracks_app.rb
+++ b/app/controllers/laugh_tracks_app.rb
@@ -1,5 +1,4 @@
 class LaughTracksApp < Sinatra::Base
-  # what does the below do?
   set :root, File.expand_path("..", __dir__)
 
   get '/comedians' do
@@ -8,6 +7,7 @@ class LaughTracksApp < Sinatra::Base
       @specials = Special.where(comedian_id: @comedians.ids)
     else
       @comedians = Comedian.all
+      @specials = Special.where(comedian_id: @comedians.ids)
     end
     erb :'comedians/index'
   end

--- a/app/controllers/laugh_tracks_app.rb
+++ b/app/controllers/laugh_tracks_app.rb
@@ -2,11 +2,13 @@ class LaughTracksApp < Sinatra::Base
   # what does the below do?
   set :root, File.expand_path("..", __dir__)
 
-  get ('/comedians') do
-    @comedians = Comedian.all
+  get '/comedians' do
+    if params[:age]
+      @comedians = Comedian.where(age: params[:age])
+      @specials = Special.where(comedian_id: @comedians.ids)
+    else
+      @comedians = Comedian.all
+    end
     erb :'comedians/index'
   end
-
-
-
 end

--- a/app/views/comedians/index.erb
+++ b/app/views/comedians/index.erb
@@ -1,8 +1,8 @@
 <section id="statistics">
   <h1>Statistics</h1>
-  <h3>Average Age of Comedians: <%=Comedian.average_age.to_i%> years old</h3>
-  <h3>Average TV Special Run Time: <%=Special.average_length.to_i%> minutes</h3>
-  <h3>All Cities: <%=Comedian.all_cities.join(", ")%></h3>
+  <h3>Average Age of Comedians: <%=@comedians.average_age.to_i%> years old</h3>
+  <h3>Average TV Special Run Time: <%=@specials.average_length.to_i%> minutes</h3>
+  <h3>All Cities: <%=@comedians.all_cities.join(", ")%></h3>
 </section>
 
 <h2>Comedians</h2>

--- a/spec/features/comedians_matching_age_spec.rb
+++ b/spec/features/comedians_matching_age_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe "Comedian of Specific Age" do
       expect(page).not_to have_content(comedian_1.name)
       expect(page).not_to have_content(comedian_4.name)
       expect(page).to have_content(comedian_2.specials.name)
+      expect(page).to have_content("Average Age of Comedians: 34 years old")
+      expect(page).to have_content(Comedian.all_cities.join(", "))
     end
   end
 end

--- a/spec/features/comedians_matching_age_spec.rb
+++ b/spec/features/comedians_matching_age_spec.rb
@@ -1,10 +1,15 @@
 RSpec.describe "Comedian of Specific Age" do
   context "When a user visits /comedians?age=34" do
-    it "shows information about matching comedians" do
+    it "shows information about matching comedians & their stats" do
       comedian_1 = Comedian.create(name: "Sally", age: 33, city: "New York")
       comedian_2 = Comedian.create(name: "Bob", age: 34, city: "New York")
       comedian_3 = Comedian.create(name: "Bill", age: 34, city: "LA")
       comedian_4 = Comedian.create(name: "Joe", age: 20, city: "LA")
+
+      comedian_1.specials.create(title: "Title 1", length: 30)
+      comedian_2.specials.create(title: "Title 2", length: 40)
+      comedian_3.specials.create(title: "Title 3", length: 25)
+      comedian_4.specials.create(title: "Title 4", length: 50)
 
       visit "/comedians?age=34"
 
@@ -12,6 +17,7 @@ RSpec.describe "Comedian of Specific Age" do
       expect(page).to have_content(comedian_3.name)
       expect(page).not_to have_content(comedian_1.name)
       expect(page).not_to have_content(comedian_4.name)
+      expect(page).to have_content(comedian_2.specials.name)
     end
   end
 end

--- a/spec/features/comedians_matching_spec.rb
+++ b/spec/features/comedians_matching_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe "Comedian of Specific Age" do
+  context "When a user visits /comedians?age=34" do
+    it "shows information about matching comedians" do
+      comedian_1 = Comedian.create(name: "Sally", age: 33, city: "New York")
+      comedian_2 = Comedian.create(name: "Bob", age: 34, city: "New York")
+      comedian_3 = Comedian.create(name: "Bill", age: 34, city: "LA")
+      comedian_4 = Comedian.create(name: "Joe", age: 20, city: "LA")
+
+      visit "/comedians?age=34"
+
+      expect(page).to have_content(comedian_2.name)
+      expect(page).to have_content(comedian_3.name)
+      expect(page).not_to have_content(comedian_1.name)
+      expect(page).not_to have_content(comedian_4.name)
+    end
+  end
+end

--- a/spec/features/comedians_spec.rb
+++ b/spec/features/comedians_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe "Comedian Index Page" do
     end
 
     it "should display an area at the top of the page called statistics" do
-      comedian_1 = Comedian.create(name: "Sally", age: 33, city: "New York")
-      comedian_2 = Comedian.create(name: "Bill", age: 23, city: "L.A.")
+      Comedian.create(name: "Sally", age: 33, city: "New York")
+      Comedian.create(name: "Bill", age: 23, city: "L.A.")
       expected = Comedian.all_cities.join(", ")
       visit '/comedians'
       within "#statistics" do

--- a/spec/models/comedian_spec.rb
+++ b/spec/models/comedian_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Comedian do
     end
   end
   describe 'Statistics' do
-    context 'When viewing all comedians'
       it 'should output correct statistics for age & city list' do
         Comedian.create(name: "Sally", age: 33, city: "New York")
         Comedian.create(name: "Bill", age: 23, city: "L.A.")
@@ -22,23 +21,5 @@ RSpec.describe Comedian do
         Comedian.create(name: "Bob", age: 77, city: "L.A.")
         expect(Comedian.all_cities).to eq ["New York", "L.A."]
       end
-    context 'When viewing comedians matching an age' do
-      it 'should ouput correct statistics' do
-        comedian_1 = Comedian.create(name: "Sally", age: 33, city: "Philly")
-        comedian_2 = Comedian.create(name: "Bob", age: 34, city: "New York")
-        comedian_3 = Comedian.create(name: "Bill", age: 34, city: "LA")
-        comedian_4 = Comedian.create(name: "Joe", age: 20, city: "Denver")
-
-        comedian_1.specials.create(title: "Title 1", length: 30)
-        comedian_2.specials.create(title: "Title 2", length: 40)
-        comedian_3.specials.create(title: "Title 3", length: 25)
-        comedian_4.specials.create(title: "Title 4", length: 50)
-
-        visit '/comedians?age=34'
-
-        expect(Comedian.average_age).to eq 34
-        expect(Comedian.all_cities).to eq ["New York", "L.A."]
-      end
-    end
   end
 end

--- a/spec/models/comedian_spec.rb
+++ b/spec/models/comedian_spec.rb
@@ -13,12 +13,32 @@ RSpec.describe Comedian do
     end
   end
   describe 'Statistics' do
-    it 'should output correct statistics for age & city list' do
-      Comedian.create(name: "Sally", age: 33, city: "New York")
-      Comedian.create(name: "Bill", age: 23, city: "L.A.")
-      expect(Comedian.average_age).to eq 28
-      Comedian.create(name: "Bob", age: 77, city: "L.A.")
-      expect(Comedian.all_cities).to eq ["New York", "L.A."]
+    context 'When viewing all comedians'
+      it 'should output correct statistics for age & city list' do
+        Comedian.create(name: "Sally", age: 33, city: "New York")
+        Comedian.create(name: "Bill", age: 23, city: "L.A.")
+        expect(Comedian.average_age).to eq 28
+
+        Comedian.create(name: "Bob", age: 77, city: "L.A.")
+        expect(Comedian.all_cities).to eq ["New York", "L.A."]
+      end
+    context 'When viewing comedians matching an age' do
+      it 'should ouput correct statistics' do
+        comedian_1 = Comedian.create(name: "Sally", age: 33, city: "Philly")
+        comedian_2 = Comedian.create(name: "Bob", age: 34, city: "New York")
+        comedian_3 = Comedian.create(name: "Bill", age: 34, city: "LA")
+        comedian_4 = Comedian.create(name: "Joe", age: 20, city: "Denver")
+
+        comedian_1.specials.create(title: "Title 1", length: 30)
+        comedian_2.specials.create(title: "Title 2", length: 40)
+        comedian_3.specials.create(title: "Title 3", length: 25)
+        comedian_4.specials.create(title: "Title 4", length: 50)
+
+        visit '/comedians?age=34'
+
+        expect(Comedian.average_age).to eq 34
+        expect(Comedian.all_cities).to eq ["New York", "L.A."]
+      end
     end
   end
 end


### PR DESCRIPTION
Completes User Story 5:

As a visitor
When I visit `/comedians?age=34`
Then I see the list of comedians on the page only shows
comedians who match the age criteria.

- All other information on the page is still expected to be present
- Testing should check that excluded comedians do not show up.