### PR TITLE
User Story 6

### DIFF
--- a/app/views/comedians/index.erb
+++ b/app/views/comedians/index.erb
@@ -1,6 +1,7 @@
 <section id="statistics">
   <h1>Statistics</h1>
   <h3>Average Age of Comedians: <%=@comedians.average_age.to_i%> years old</h3>
+  <h3>Total TV Specials: <%= @specials.count %></h3>
   <h3>Average TV Special Run Time: <%=@specials.average_length.to_i%> minutes</h3>
   <h3>All Cities: <%=@comedians.all_cities.join(", ")%></h3>
 </section>

--- a/app/views/comedians/index.erb
+++ b/app/views/comedians/index.erb
@@ -8,15 +8,14 @@
 <h2>Comedians</h2>
   <% @comedians.each do |comedian| %>
     <div id="comedian-<%=comedian.id%>">
-      <p>
-        <%= comedian.name %>
-        Age: <%= comedian.age %>
-        City: <%= comedian.city %>
+      <p><%= comedian.name %></p>
+      <p>Age: <%= comedian.age %></p>
+      <p>City: <%= comedian.city %></p>
+      <p>Total Specials: <%= comedian.specials.count %></p>
 
-      </p>
       <% comedian.specials.each do |special| %>
-        <%=special.title%>
-        Length: <%=special.length%>
+        <p><%=special.title%></p>
+        <p>Length: <%=special.length%></p>
         <img src="<%= special.photo %>">
       <% end %>
     </div>

--- a/spec/features/comedians_spec.rb
+++ b/spec/features/comedians_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "Comedian Index Page" do
         expect(page).to have_content("Average Age of Comedians: #{Comedian.average_age.to_i} years old")
         expect(page).to have_content("All Cities: #{Comedian.all_cities.join(", ")}")
         expect(page).to have_content("Average TV Special Run Time: #{Special.average_length.to_i} minutes")
+        expect(page).to have_content("Total TV Specials: #{Special.count}")
       end
     end
 

--- a/spec/features/comedians_spec.rb
+++ b/spec/features/comedians_spec.rb
@@ -28,18 +28,18 @@ RSpec.describe "Comedian Index Page" do
         expect(page).to have_content(special_2.title)
         expect(page).to have_content("Length: #{special_2.length}")
         expect(page).to have_css("img[src='#{special_2.photo}']")
+        expect(page).to have_content("Total Specials: #{comedian_1.specials.count}")
       end
     end
 
     it "should display an area at the top of the page called statistics" do
       Comedian.create(name: "Sally", age: 33, city: "New York")
       Comedian.create(name: "Bill", age: 23, city: "L.A.")
-      expected = Comedian.all_cities.join(", ")
       visit '/comedians'
       within "#statistics" do
         expect(page).to have_content("Statistics")
         expect(page).to have_content("Average Age of Comedians: #{Comedian.average_age.to_i} years old")
-        expect(page).to have_content("All Cities: #{expected}")
+        expect(page).to have_content("All Cities: #{Comedian.all_cities.join(", ")}")
         expect(page).to have_content("Average TV Special Run Time: #{Special.average_length.to_i} minutes")
       end
     end

--- a/spec/models/comedian_spec.rb
+++ b/spec/models/comedian_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Comedian do
     end
   end
   describe 'Statistics' do
-      it 'should output correct statistics for age & city list' do
+      it 'should output correct statistics for: age & cities' do
         Comedian.create(name: "Sally", age: 33, city: "New York")
         Comedian.create(name: "Bill", age: 23, city: "L.A.")
         expect(Comedian.average_age).to eq 28

--- a/spec/models/special_spec.rb
+++ b/spec/models/special_spec.rb
@@ -13,11 +13,19 @@ RSpec.describe Special do
   end
   describe 'Visiting the Index Page' do
     describe 'Statistics' do
-      it 'should output average special run time' do
-        Special.create(title: "Title 1", length: 30)
-        Special.create(title: "Title 2", length: 40)
-        Special.create(title: "Title 3", length: 50)
-        expect(Special.average_length).to eq 40
+      it 'should output an average run time & special count' do
+        comedian_1 = Comedian.create(name: "Sally", age: 33, city: "New York")
+        comedian_2 = Comedian.create(name: "Bob", age: 34, city: "New York")
+        comedian_3 = Comedian.create(name: "Bill", age: 34, city: "LA")
+        comedian_4 = Comedian.create(name: "Joe", age: 20, city: "LA")
+
+        comedian_1.specials.create(title: "Title 1", length: 30)
+        comedian_2.specials.create(title: "Title 2", length: 40)
+        comedian_3.specials.create(title: "Title 3", length: 25)
+        comedian_4.specials.create(title: "Title 4", length: 50)
+
+        expect(Special.average_length).to eq 36.25
+        expect(comedian_1.specials.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
As a visitor
When I visit `/comedians`
For each comedian, I see a count of their TV specials
and the Statistics area on the page should list a total count
of TV specials for every comedian.