### PR TITLE
User Story 7

### DIFF
--- a/app/views/comedians/index.erb
+++ b/app/views/comedians/index.erb
@@ -1,3 +1,4 @@
+<!doctype html>
 <section id="statistics">
   <h1>Statistics</h1>
   <h3>Average Age of Comedians: <%=@comedians.average_age.to_i%> years old</h3>

--- a/spec/features/comedians_matching_age_spec.rb
+++ b/spec/features/comedians_matching_age_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "Comedian of Specific Age" do
 
       expect(page).to have_content(comedian_2.name)
       expect(page).to have_content(comedian_3.name)
-      expect(page).not_to have_content(comedian_1.name)
-      expect(page).not_to have_content(comedian_4.name)
+      expect(page).to_not have_content(comedian_1.name)
+      expect(page).to_not have_content(comedian_4.name)
       expect(page).to have_content(comedian_2.specials.name)
       expect(page).to have_content("Average Age of Comedians: 34 years old")
       expect(page).to have_content(Comedian.all_cities.join(", "))


### PR DESCRIPTION
As a visitor
When I visit `/comedians?age=34`
Then I see a list of all comedians with an age of 34
Just like a previous User Story, BUT all other statistics 
information in the 'Statistics' area of the page should be limited 
to reflect only the information about the comedians listed on 
the page.

- Testing ensures that calculated statistics are
  correct for a limited subset of data